### PR TITLE
Silence out some warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -214,7 +214,7 @@ AC_SUBST(WEBKIT_CFLAGS)
 AC_SUBST(WEBKIT_LIBS)
 
 
-PKG_CHECK_MODULES(LIBSOUP, libsoup-2.4 >= 2.4,,AC_MSG_ERROR(libsoup-2.4 development version >= 2.4 is needed.))
+PKG_CHECK_MODULES(LIBSOUP, libsoup-2.4 >= 2.42,,AC_MSG_ERROR(libsoup-2.4 development version >= 2.42 is needed.))
 AC_SUBST(LIBSOUP_CFLAGS)
 AC_SUBST(LIBSOUP_LIBS)
 

--- a/src/gui_navigation.cpp
+++ b/src/gui_navigation.cpp
@@ -36,8 +36,27 @@
 
 GuiNavigation::GuiNavigation(int dummy): track(0)
 {
-  // Initialize variables.
+  // Initialize members.
   parentToolbar = NULL;
+  new_reference_signal = NULL;
+  button_list_back = NULL;
+  image_list_back = NULL;
+  button_back = NULL;
+  image1 = NULL;
+  button_forward = NULL;
+  image2 = NULL;
+  button_list_forward = NULL;
+  image_list_forward = NULL;
+  combo_book = NULL;
+  spinbutton_book_adj = NULL;
+  spinbutton_book = NULL;
+  combo_chapter = NULL;
+  spinbutton_chapter_adj = NULL;
+  spinbutton_chapter = NULL;
+  combo_verse = NULL;
+  spinbutton_verse_adj = NULL;
+  spinbutton_verse = NULL;
+  entry_free = NULL;
   settingcombos = false;
   spinbutton_book_previous_value = 0;
   spinbutton_chapter_previous_value = 0;

--- a/src/gwrappers.cpp
+++ b/src/gwrappers.cpp
@@ -238,6 +238,7 @@ GwSpawn::GwSpawn(const ustring &program)
   myallowcancel = false;
   myhide = false;
   cancelled = false;
+  result = false;
   exitstatus = 0;
   pid = 0;
 }

--- a/src/urltransport.cpp
+++ b/src/urltransport.cpp
@@ -30,7 +30,8 @@
 URLTransport::URLTransport(int dummy)
 // URL transporter.
 {
-  // Init variables.
+  // Init members.
+  reply_is_ok = false;
   sequential_messages_in_transit = false;
   
   // Create a session.

--- a/src/urltransport.cpp
+++ b/src/urltransport.cpp
@@ -39,10 +39,10 @@ URLTransport::URLTransport(int dummy)
   // This is done so that only one messages is posted at a time. If more are posted,
   // the messages get posted out of order, and this may cause confusion in particular
   // when doing the various git commands out of order.
-  session = soup_session_async_new_with_options (SOUP_SESSION_USER_AGENT, "bibledit/1.0", 
-                                                 SOUP_SESSION_MAX_CONNS, "50", 
-                                                 SOUP_SESSION_MAX_CONNS_PER_HOST, "50",
-                                                 NULL);
+  session = soup_session_new_with_options (SOUP_SESSION_USER_AGENT, "bibledit/1.0",
+                                           SOUP_SESSION_MAX_CONNS, "50",
+                                           SOUP_SESSION_MAX_CONNS_PER_HOST, "50",
+                                           NULL);
   //SoupLogger *logger;
   //logger = soup_logger_new(SOUP_LOGGER_LOG_HEADERS, -1);
   //logger = soup_logger_new(SOUP_LOGGER_LOG_BODY, -1);


### PR DESCRIPTION
This pull request silences out almost all warnings I found while compiling. I'm not sure they caused any real problems but will remove some noise from the build log.

There are more things to fix, though.