### PR TITLE
Floating window: Optimize the formatting of the title.

### DIFF
--- a/templates/gtkbuilder.floatingwindow.xml
+++ b/templates/gtkbuilder.floatingwindow.xml
@@ -47,6 +47,9 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="ellipsize">middle</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0.5</property>
+                        <property name="xpad">20</property>
                       </object>
                     </child>
                   </object>


### PR DESCRIPTION
**Please do not yet merge** this pull request because most likely it will break the things in ```gtk3``` branch. I should prepare another pull request for ```gtk3```.

The text of ```label_title``` is set only once in ```title_change()``` while
```title_setfocused()``` only updates the color and font weight of the label.
All ```label_title``` properties which do not change when a selected floating
window changes are moved to the XML template.