### PR TITLE
Close buttons in the tabbed windows

### DIFF
--- a/src/windowtabbed.cpp
+++ b/src/windowtabbed.cpp
@@ -250,6 +250,13 @@ void WindowTabbed::on_page_removed_event(GtkNotebook *notebook,
 
 void WindowTabbed::on_page_removed(const int page_num) {
 	tabs.erase(tabs.begin() + page_num);
+	// Was that the last tab? If yes close the window.
+	// It looks dangerous to emit a signal which eventually deletes this
+	// object from its non-static member function but it seems to work
+	// so far. Maybe because this is the last line of the function and
+	// we are not referring to this object which becomes invalid.
+	if (tabs.empty())
+		gtk_button_clicked(GTK_BUTTON(delete_signal_button));
 }
 
 void SingleTab::updateHtml(HtmlWriter2 &html)

--- a/src/windowtabbed.h
+++ b/src/windowtabbed.h
@@ -58,6 +58,7 @@ private:
     friend class WindowTabbed;
     
     // Callbacks. These routines are replicated several times throughout the code base. Any way to refactor so as to simplify?
+    static void on_close_button_clicked (GtkButton *button, gpointer user_data);
     static gboolean on_navigation_policy_decision_requested (WebKitWebView *web_view, WebKitWebFrame *frame, WebKitNetworkRequest *request, WebKitWebNavigationAction *navigation_action, WebKitWebPolicyDecision *policy_decision, gpointer user_data);
     void navigation_policy_decision_requested (WebKitNetworkRequest *request, WebKitWebNavigationAction *navigation_action, WebKitWebPolicyDecision *policy_decision);
     void html_link_clicked (const gchar * url);
@@ -84,6 +85,9 @@ public:
     GtkWidget *notebook;
     vector<SingleTab *> tabs;
     bool ready;
+    static void on_page_removed_event(GtkNotebook *notebook,
+            GtkWidget *child, guint page_num, gpointer user_data);
+    void on_page_removed(const int page_num);
  public:
     void setReady(bool _ready) { ready = _ready; }
     bool getReady(void)        { return ready; }


### PR DESCRIPTION
There are 2 commits in this pull request. The second one is an additional feature: close the floating window when its last tab is closed. This is what Firefox is doing, for example. I thought that this feature was reasonable. If not, feel free to reject it. Also, feel free to squash these commits if you find this necessary.

Please test this before you accept. I have tested and it seems OK but the memory management looks scary to me sometimes.

If you accept then please rebase the ```gtk3``` branch against the new ```master```. This code seems to work correctly in GTK 3.x and the results look nice but it may happen to use some deprecated features. It's not a big problem and I will contribute the updates to ```gtk3``` when we finish this chunk of updates to ```master```.