### PR TITLE
Floating window: Nice close button

### DIFF
--- a/src/floatingwindow.cpp
+++ b/src/floatingwindow.cpp
@@ -69,13 +69,10 @@ FloatingWindow::FloatingWindow(GtkWidget * layout_in, WindowID window_id_in, ust
   g_signal_connect ((gpointer) eventbox_title, "enter_notify_event", G_CALLBACK (on_titlebar_enter_notify_event), gpointer (this));
   g_signal_connect ((gpointer) eventbox_title, "leave_notify_event", G_CALLBACK (on_titlebar_leave_notify_event), gpointer (this));
     
-  GtkWidget *eventbox_close;
-  eventbox_close = GTK_WIDGET (gtk_builder_get_object (gtkbuilder, "eventbox_close"));
-  label_close = GTK_WIDGET (gtk_builder_get_object (gtkbuilder, "label_close"));
-  g_signal_connect ((gpointer) eventbox_close, "button_press_event", G_CALLBACK (on_widget_button_press_event), gpointer (this));
-  g_signal_connect ((gpointer) eventbox_close, "enter_notify_event", G_CALLBACK (on_label_close_enter_notify_event), gpointer (this));
-  g_signal_connect ((gpointer) eventbox_close, "leave_notify_event", G_CALLBACK (on_label_close_leave_notify_event), gpointer (this));
-  g_signal_connect ((gpointer) eventbox_close, "button_press_event", G_CALLBACK (on_label_close_button_press_event), gpointer (this));
+  GtkWidget *button_close;
+  button_close = GTK_WIDGET (gtk_builder_get_object (gtkbuilder, "button_close"));
+  g_signal_connect ((gpointer) button_close, "button_press_event", G_CALLBACK (on_widget_button_press_event), gpointer (this));
+  g_signal_connect ((gpointer) button_close, "clicked", G_CALLBACK (on_button_close_clicked), gpointer (this));
 
   GtkWidget *eventbox_client;
   eventbox_client = GTK_WIDGET (gtk_builder_get_object (gtkbuilder, "eventbox_client"));
@@ -348,50 +345,15 @@ void FloatingWindow::clear_previous_root_coordinates ()
 }
 
 
-gboolean FloatingWindow::on_label_close_enter_notify_event (GtkWidget *widget, GdkEventCrossing *event, gpointer user_data)
+void FloatingWindow::on_button_close_clicked (GtkButton *button, gpointer user_data)
 {
-  return ((FloatingWindow *) user_data)->on_label_close_enter_notify(event);
+  ((FloatingWindow *) user_data)->on_button_close ();
 }
 
 
-gboolean FloatingWindow::on_label_close_enter_notify (GdkEventCrossing *event)
-{
-  // Set the cursor to a shape that shows that the action label can be clicked.
-  GtkWidget *toplevel_widget = gtk_widget_get_toplevel(label_close);
-  GdkWindow *gdk_window = gtk_widget_get_window (toplevel_widget);
-  GdkCursor *cursor = gdk_cursor_new(GDK_HAND2);
-  gdk_window_set_cursor(gdk_window, cursor);
-  gdk_cursor_unref (cursor);
-  return false;
-}
-
-
-gboolean FloatingWindow::on_label_close_leave_notify_event (GtkWidget *widget, GdkEventCrossing *event, gpointer user_data)
-{
-  return ((FloatingWindow *) user_data)->on_label_close_leave_notify(event);
-}
-
-
-gboolean FloatingWindow::on_label_close_leave_notify (GdkEventCrossing *event)
-{
-  // Restore the original cursor.
-  GtkWidget * toplevel_widget = gtk_widget_get_toplevel(label_close);
-  GdkWindow *gdk_window = gtk_widget_get_window (toplevel_widget);
-  gdk_window_set_cursor(gdk_window, NULL);
-  return false;
-}
-
-
-gboolean FloatingWindow::on_label_close_button_press_event (GtkWidget *widget, GdkEventButton *event, gpointer user_data)
-{
-  return ((FloatingWindow *) user_data)->on_label_close_button_press(event);
-}
-
-
-gboolean FloatingWindow::on_label_close_button_press (GdkEventButton *event)
+void FloatingWindow::on_button_close ()
 {
   gtk_button_clicked(GTK_BUTTON(delete_signal_button));
-  return false;
 }
 
 

--- a/src/floatingwindow.h
+++ b/src/floatingwindow.h
@@ -39,8 +39,6 @@ private:
   GtkWidget *vbox_window;
 public:
   GtkWidget *label_title;
-private:
-  GtkWidget *label_close;
 public:
   GtkWidget *vbox_client;
 private:
@@ -74,14 +72,10 @@ private:
   gboolean on_statusbar_enter_notify (GdkEventCrossing *event);
   static gboolean on_statusbar_leave_notify_event (GtkWidget *widget, GdkEventCrossing *event, gpointer user_data);
   gboolean on_statusbar_leave_notify (GdkEventCrossing *event);
-  static gboolean on_label_close_enter_notify_event (GtkWidget *widget, GdkEventCrossing *event, gpointer user_data);
-  gboolean on_label_close_enter_notify (GdkEventCrossing *event);
-  static gboolean on_label_close_leave_notify_event (GtkWidget *widget, GdkEventCrossing *event, gpointer user_data);
-  gboolean on_label_close_leave_notify (GdkEventCrossing *event);
 
-  // Close link.
-  static gboolean on_label_close_button_press_event (GtkWidget *widget, GdkEventButton *event, gpointer user_data);
-  gboolean on_label_close_button_press (GdkEventButton *event);
+  // Close button
+  static void on_button_close_clicked (GtkButton *button, gpointer user_data);
+  void on_button_close ();
 
 private:  
   ustring title;

--- a/templates/gtkbuilder.floatingwindow.xml
+++ b/templates/gtkbuilder.floatingwindow.xml
@@ -60,21 +60,23 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkEventBox" id="eventbox_close">
+                  <object class="GtkButton" id="button_close">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="focus_on_click">False</property>
+                    <property name="relief">GTK_RELIEF_NONE</property>
                     <child>
-                      <object class="GtkLabel" id="label_close">
+                      <object class="GtkImage" id="image_close">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label">x</property>
+                        <property name="stock">gtk-close</property>
+                        <property name="icon_size">1</property>
                       </object>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
-                    <property name="padding">4</property>
+                    <property name="padding">0</property>
                     <property name="position">1</property>
                   </packing>
                 </child>


### PR DESCRIPTION
This commit also drops the feature to change the mouse cursor to
a pointing hand when the mouse is over the close button.

This is related with the issue #57 although does not resolve it.