### PR TITLE
Floating window: simplify the UI template

### DIFF
--- a/templates/gtkbuilder.floatingwindow.xml
+++ b/templates/gtkbuilder.floatingwindow.xml
@@ -1,36 +1,14 @@
+<!--
+  Note: No matter how ugly it looks don't reformat this file until we
+  fully port to GTK 3.x or otherwise you will get bad rebase conflicts.
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <!-- interface-requires gtk+ 3.0 -->
-  <object class="GtkVBox" id="vbox_window">
+  <object class="GtkFrame" id="vbox_window">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <child>
-      <object class="GtkHSeparator" id="hseparator_top">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">False</property>
-        <property name="position">0</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkHBox" id="hbox_window">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <child>
-          <object class="GtkVSeparator" id="vseparator_left">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkVBox" id="vbox_main">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
@@ -193,37 +171,7 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
           </packing>
         </child>
-        <child>
-          <object class="GtkVSeparator" id="vseparator_right">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-      </object>
-      <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkHSeparator" id="hseparator_bottom">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">False</property>
-        <property name="position">2</property>
-      </packing>
-    </child>
   </object>
 </interface>


### PR DESCRIPTION
Remove separators and some nested boxes whose job was to draw a box
around the window, use GtkFrame instead.