### PR TITLE
Config: Enable silent rules by default.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,7 @@ AC_CANONICAL_SYSTEM
 ac_default_prefix=/usr
 AC_CONFIG_SRCDIR([src])
 AM_INIT_AUTOMAKE([1.9 tar-ustar])
+AM_SILENT_RULES([yes])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 LT_INIT


### PR DESCRIPTION
As per the suggestion in https://github.com/postiffm/bibledit-desktop/pull/101#issuecomment-480240458.