### PR TITLE
Bugfix: Do not use nonexisting child properties of GtkFrame.

### DIFF
--- a/templates/gtkbuilder.floatingwindow.xml
+++ b/templates/gtkbuilder.floatingwindow.xml
@@ -164,10 +164,6 @@
               </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-          </packing>
         </child>
   </object>
 </interface>


### PR DESCRIPTION
This commit gets rid of the warnings "GtkFrame does not have a child
property called expand" and "... fill". Indeed, GtkFrame does not have
these properties and they just should have been removed.

The bug was introduced by commit f42eaa30b470287c10108da42757997cdffefaf0.