### PR TITLE
Correct linux menu launch shortcut

### DIFF
--- a/desktop/Makefile.am
+++ b/desktop/Makefile.am
@@ -1,6 +1,6 @@
 applicationdir = $(datadir)/applications
 
-application_DATA = bibledit-gtk.desktop
+application_DATA = bibledit-desktop.desktop
 
 EXTRA_DIST = *
 CLEANFILES = *~

--- a/desktop/bibledit-desktop.desktop
+++ b/desktop/bibledit-desktop.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
-Name=Bibledit-Gtk
+Name=Bibledit-Desktop
 Comment=Bible Editor
-Icon=bibledit
-Exec=bibledit-gtk
+Icon=bibledit-desktop.xpm
+Exec=bibledit-desktop
 Type=Application
 Categories=Office;
 StartupNotify=true

--- a/linux/DEBUGGING.txt
+++ b/linux/DEBUGGING.txt
@@ -1,4 +1,4 @@
-This is a description of how to debug bibledit-gtk on Linux.
+This is a description of how to debug bibledit-desktop on Linux.
 It assumes you have already gone through the BUILDING process
 and the INSTALLING process.
 Written by Matt Postiff, postiffm@umich.edu, 8/25/2016
@@ -81,7 +81,7 @@ It has to link with -lasan (libasan) and this is apparently not available on Win
 
 Then run the program like this:
 
-ASAN_OPTIONS="symbolize=1 log_path=/tmp/bibledit/asan.log" ASAN_SYMBOLIZER_PATH=$(shell which llvm-symbolizer-3.8) /usr/bin/bibledit-gtk
+ASAN_OPTIONS="symbolize=1 log_path=/tmp/bibledit/asan.log" ASAN_SYMBOLIZER_PATH=$(shell which llvm-symbolizer-3.8) /usr/bin/bibledit-desktop
 
 Use ASAN_OPTIONS=help=1 to get a list of current options.
 
@@ -89,7 +89,7 @@ This does run noticeably slower. The confusing thing is that the output does not
 for the given test case. I think that is because we redirect stdout...
 
 2. To use Valgrind
-valgrind --leak-check=full -v --track-origins=yes /usr/bin/bibledit-gtk >& memory.txt
+valgrind --leak-check=full -v --track-origins=yes /usr/bin/bibledit-desktop >& memory.txt
 
 It runs very slowly, but it gives good information on memory leaks
 and things like conditional jumps that rely on uninitialized memory.

--- a/linux/objdump-recursive.pl
+++ b/linux/objdump-recursive.pl
@@ -9,7 +9,7 @@
 # Modified by Matt Postiff (postiffm@umich.edu)
 # Version 1.1 on March 28, 2016 for bibledit
 # Original: https://gist.github.com/Tomonobu3110/963cfc63d8a3b94b55cf
-# Usage example: linux/objdump-recursive.pl --uniq "/c/Program Files (x86)/Bibledit-4.9.3/editor/bin/bibledit-gtk.exe" | sort
+# Usage example: linux/objdump-recursive.pl --uniq "/c/Program Files (x86)/Bibledit-4.9.3/editor/bin/bibledit-desktop.exe" | sort
 #
 # This program performs recursive objdump checks for binaries and libraries
 # It recurses through entire objdump tree for every listed binary and library

--- a/man/bibledit-git.1
+++ b/man/bibledit-git.1
@@ -3,7 +3,7 @@
 .B bibledit-git \- internal command for bibledit, a Bible editor
 .SH DESCRIPTION
 Bibledit is a Bible editor.
-It is started by typing "bibledit-gtk" on
+It is started by typing "bibledit-desktop" on
 the commandline. 
 Binary "bibledit-git" is used by Bibledit internally.
 For more information see the 

--- a/man/bibledit-gtk.1
+++ b/man/bibledit-gtk.1
@@ -3,7 +3,7 @@
 .B bibledit-gtk \- a Bible editor
 .SH DESCRIPTION
 Bibledit-Gtk is a Bible editor.
-It is started by typing "bibledit-gtk" on
+It is started by typing "bibledit-desktop" on
 the commandline. For more information see the 
 online help of the graphical user interface.
 .PP

--- a/man/bibledit-shutdown.1
+++ b/man/bibledit-shutdown.1
@@ -1,9 +1,9 @@
 .TH BIBLEDIT-SHUTDOWN 1 "April 10 2012" "Version 4.6"
 .SH NAME
-.B bibledit-shutdown \- internal command for bibledit-gtk, a Bible editor
+.B bibledit-shutdown \- internal command for bibledit-desktop, a Bible editor
 .SH DESCRIPTION
 Bibledit is a Bible editor.
-It is started by typing "bibledit-gtk" on
+It is started by typing "bibledit-desktop" on
 the commandline. 
 Binary "bibledit-shutdown" is used by Bibledit internally.
 .PP

--- a/windows/buildenvWin64.sh
+++ b/windows/buildenvWin64.sh
@@ -72,7 +72,6 @@ pacman -S --noconfirm msys/libxml2-devel
 mkdir -v -p ~/$BUILD_DIR
 cd ~/$BUILD_DIR
 #git clone https://github.com/teusbenschop/bibledit.git
-#git clone https://github.com/postiffm/bibledit-gtk.git
 git clone https://github.com/postiffm/bibledit-desktop.git
 echo "Git cloned into the directory ~/$BUILD_DIR/bibledit-desktop"
 


### PR DESCRIPTION
The linux gtk menu launcher was incorrectly set to exec bibledit-gtk it should be bibledit-desktop.

The icon entry also did not refer to an actual icon, this commit change it to the xpm icon.
The commit also changes references to bibledit-gtk. Readme and changelog reference were not changed.