### PR TITLE
Update makefile for pixmap

### DIFF
--- a/pix/Makefile.am
+++ b/pix/Makefile.am
@@ -1,4 +1,7 @@
 SUBDIRS = hicolor
 
+appicondir = $(datadir)/pixmaps
+appicon_DATA = bibledit-desktop.xpm
+
 dist_pkgdata_DATA = *.xpm *.jpeg *.ico *.svg *.gif *.png
 CLEANFILES = *~


### PR DESCRIPTION
The changes readd assigments that will install the xpm icon into the pixmaps folder.
This fixes no icon appearing for the menu item.